### PR TITLE
fix(extension): #37: add loader to rpc validation

### DIFF
--- a/apps/extension/src/shared/components/grpc-endpoint-form/index.tsx
+++ b/apps/extension/src/shared/components/grpc-endpoint-form/index.tsx
@@ -1,7 +1,7 @@
 import { FormEvent, useRef } from 'react';
 import { SelectList } from '@repo/ui/components/ui/select-list';
 import { Button } from '@repo/ui/components/ui/button';
-import { Network } from 'lucide-react';
+import { Network, Loader2 } from 'lucide-react';
 import { useGrpcEndpointForm } from './use-grpc-endpoint-form';
 import { ConfirmChangedChainIdDialog } from './confirm-changed-chain-id-dialog';
 import { ChainIdOrError } from './chain-id-or-error';
@@ -29,6 +29,7 @@ export const GrpcEndpointForm = ({
     rpcError,
     isSubmitButtonEnabled,
     isCustomGrpcEndpoint,
+    isValidationLoading,
   } = useGrpcEndpointForm();
   const customGrpcEndpointInput = useRef<HTMLInputElement | null>(null);
 
@@ -98,7 +99,7 @@ export const GrpcEndpointForm = ({
           </div>
 
           <Button variant='gradient' type='submit' disabled={!isSubmitButtonEnabled}>
-            {submitButtonLabel}
+            {isValidationLoading ? <Loader2 className='size-4 animate-spin' /> : submitButtonLabel}
           </Button>
         </form>
 

--- a/apps/extension/src/shared/components/grpc-endpoint-form/index.tsx
+++ b/apps/extension/src/shared/components/grpc-endpoint-form/index.tsx
@@ -99,7 +99,14 @@ export const GrpcEndpointForm = ({
           </div>
 
           <Button variant='gradient' type='submit' disabled={!isSubmitButtonEnabled}>
-            {isValidationLoading ? <Loader2 className='size-4 animate-spin' /> : submitButtonLabel}
+            {isValidationLoading ? (
+              <>
+                <Loader2 className='mr-2 size-4 animate-spin' />
+                Validating RPC
+              </>
+            ) : (
+              submitButtonLabel
+            )}
           </Button>
         </form>
 

--- a/apps/extension/src/shared/components/grpc-endpoint-form/use-grpc-endpoint-form.ts
+++ b/apps/extension/src/shared/components/grpc-endpoint-form/use-grpc-endpoint-form.ts
@@ -35,6 +35,7 @@ export const useGrpcEndpointForm = () => {
   const [grpcEndpointInput, setGrpcEndpointInput] = useState<string>('');
   const [rpcError, setRpcError] = useState<string>();
   const [isSubmitButtonEnabled, setIsSubmitButtonEnabled] = useState(false);
+  const [isValidationLoading, setIsValidationLoading] = useState(false);
   const [confirmChangedChainIdPromise, setConfirmChangedChainIdPromise] = useState<
     PromiseWithResolvers<void> | undefined
   >();
@@ -56,6 +57,7 @@ export const useGrpcEndpointForm = () => {
       if (!isValidUrl(grpcEndpointInput)) return;
 
       try {
+        setIsValidationLoading(true);
         const trialClient = createPromiseClient(
           AppService,
           createGrpcWebTransport({ baseUrl: grpcEndpointInput }),
@@ -83,6 +85,8 @@ export const useGrpcEndpointForm = () => {
         } else {
           setRpcError('Could not connect to endpoint: ' + String(e));
         }
+      } finally {
+        setIsValidationLoading(false);
       }
     }, 400);
   }, []);
@@ -150,5 +154,6 @@ export const useGrpcEndpointForm = () => {
     onSubmit,
     isSubmitButtonEnabled,
     isCustomGrpcEndpoint,
+    isValidationLoading,
   };
 };


### PR DESCRIPTION
Closes #37 

Add a loader to the RPC selection setting page

<img width="397" alt="image" src="https://github.com/prax-wallet/web/assets/29180358/4b598aa3-e202-403f-bb1e-a058dd2f39e1">