### PR TITLE
fix: trim trailing slash from custom rpc url

### DIFF
--- a/apps/extension/src/shared/components/default-frontend-form/index.tsx
+++ b/apps/extension/src/shared/components/default-frontend-form/index.tsx
@@ -22,7 +22,11 @@ const getFrontendsFromRegistry = (selectedRpc?: string): DisplayedFrontend[] => 
   }));
 
   if (selectedRpc) {
-    registeredFrontends.push({ title: 'Embedded RPC frontend', url: `${selectedRpc}/app/` });
+    registeredFrontends.push({
+      title: 'Embedded RPC frontend',
+      /*NB: we merge using the variadic URL constructor here to avoid double-slashes*/
+      url: new URL('/app/', selectedRpc).href,
+    });
   }
 
   return registeredFrontends;

--- a/apps/extension/src/shared/components/grpc-endpoint-form/index.tsx
+++ b/apps/extension/src/shared/components/grpc-endpoint-form/index.tsx
@@ -76,7 +76,7 @@ export const GrpcEndpointForm = ({
                   placeholder='Enter URL'
                   ref={customGrpcEndpointInput}
                   value={isCustomGrpcEndpoint && !!grpcEndpointInput ? grpcEndpointInput : ''}
-                  onChange={e => setGrpcEndpointInput(e.target.value)}
+                  onChange={e => setGrpcEndpointInput(e.target.value.replace(/\/$/, ''))}
                   className='w-full rounded border border-secondary bg-background p-1 outline-0 transition hover:border-gray-400 focus:border-gray-400'
                 />
               }

--- a/apps/extension/src/shared/components/grpc-endpoint-form/index.tsx
+++ b/apps/extension/src/shared/components/grpc-endpoint-form/index.tsx
@@ -76,7 +76,7 @@ export const GrpcEndpointForm = ({
                   placeholder='Enter URL'
                   ref={customGrpcEndpointInput}
                   value={isCustomGrpcEndpoint && !!grpcEndpointInput ? grpcEndpointInput : ''}
-                  onChange={e => setGrpcEndpointInput(e.target.value.replace(/\/$/, ''))}
+                  onChange={e => setGrpcEndpointInput(e.target.value)}
                   className='w-full rounded border border-secondary bg-background p-1 outline-0 transition hover:border-gray-400 focus:border-gray-400'
                 />
               }


### PR DESCRIPTION
Fixes edge case where entering a custom RPC URL with a trailing slash will result in links in other parts of the app being broken.

@grod220 I couldn't find a corresponding test file for this form - should I create one?

