### PR TITLE
feat(ui): display epoch index in undelegate transaction action

### DIFF
--- a/packages/ui/components/ui/tx/actions-views/undelegate.tsx
+++ b/packages/ui/components/ui/tx/actions-views/undelegate.tsx
@@ -13,6 +13,12 @@ export const UndelegateComponent = ({ value }: { value: Undelegate }) => {
       label='Undelegate'
       visibleContent={
         <ActionDetails>
+          {!!value.fromEpoch && (
+            <ActionDetails.Row label='Epoch index'>
+              {value.fromEpoch.index.toString()}
+            </ActionDetails.Row>
+          )}
+
           {!!value.delegationAmount && (
             <ActionDetails.Row label='Delegation amount'>
               {joinLoHiAmount(value.delegationAmount).toString()}


### PR DESCRIPTION
Syncs Prax TX display with Penumbra, copies https://github.com/penumbra-zone/web/pull/1384