### PR TITLE
Disable the Copy button for the seed phrase until it's revealed

### DIFF
--- a/.changeset/serious-crews-dream.md
+++ b/.changeset/serious-crews-dream.md
@@ -1,0 +1,5 @@
+---
+'chrome-extension': patch
+---
+
+Disable the Copy button for the seed phrase until it's revealed

--- a/apps/extension/src/routes/page/onboarding/generate.tsx
+++ b/apps/extension/src/routes/page/onboarding/generate.tsx
@@ -53,6 +53,7 @@ export const GenerateSeedPhrase = () => {
               ))}
             </div>
             <CopyToClipboard
+              disabled={!reveal}
               text={phrase.join(' ')}
               label={<span className='font-bold text-muted-foreground'>Copy to clipboard</span>}
               className='m-auto w-48'


### PR DESCRIPTION
Previously, you could click the (blurred-out) "Copy" button for the seed phrase even before you'd clicked "Reveal". This fixes that.

Closes #73