### PR TITLE
fix: shorten sync time to at most two units

### DIFF
--- a/packages/ui/components/ui/block-sync-status/hooks.ts
+++ b/packages/ui/components/ui/block-sync-status/hooks.ts
@@ -49,7 +49,9 @@ export const useSyncProgress = (
   const blocksRemaining = Number(latestKnownBlockHeight - fullSyncHeight);
   const timeRemaining = speed > 0 ? blocksRemaining / speed : Infinity;
   const formattedTimeRemaining =
-    timeRemaining === Infinity ? '' : humanizeDuration(timeRemaining * 1000, { round: true });
+    timeRemaining === Infinity
+      ? ''
+      : humanizeDuration(timeRemaining * 1000, { round: true, largest: 2 });
 
   return { formattedTimeRemaining, confident };
 };


### PR DESCRIPTION
fixes https://github.com/penumbra-zone/web/issues/1233

This constraints the sync estimate text to at most two largest units. This means that instead of "5 days, 3 hours, 10 minutes and 3 seconds" this will show "5 days and 3 hours", or "13 minutes, 44 seconds" etc.

