### PR TITLE
only inject to https

### DIFF
--- a/apps/extension/public/manifest.json
+++ b/apps/extension/public/manifest.json
@@ -16,7 +16,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["<all_urls>"],
+      "matches": ["https://*/*"],
       "js": [
         "injected-connection-port.js",
         "injected-disconnect-listener.js",
@@ -25,7 +25,7 @@
       "run_at": "document_start"
     },
     {
-      "matches": ["<all_urls>"],
+      "matches": ["https://*/*"],
       "js": ["injected-penumbra-global.js"],
       "run_at": "document_start",
       "world": "MAIN"


### PR DESCRIPTION
content scripts injected to http never actually achieved sentience, but they should probably still be restricted to https.