### PR TITLE
fix: don't auto-animate children of box

### DIFF
--- a/packages/ui/components/ui/box/index.tsx
+++ b/packages/ui/components/ui/box/index.tsx
@@ -74,11 +74,7 @@ export const Box = ({
         </div>
       )}
 
-      {children && (
-        <motion.div layout className='origin-top' animate={{ scaleY: 1 }} exit={{ scaleY: 0 }}>
-          {children}
-        </motion.div>
-      )}
+      {children && <motion.div className='origin-top'>{children}</motion.div>}
     </motion.div>
   );
 };


### PR DESCRIPTION
WIP: waiting on @jessepinho to confirm the parent-box layout animation doesn't break anything.

fixes #78 