### PR TITLE
fix(extension): #118: truncate the URL of connected sites

### DIFF
--- a/apps/extension/src/routes/popup/settings/settings-connected-sites/known-site.tsx
+++ b/apps/extension/src/routes/popup/settings/settings-connected-sites/known-site.tsx
@@ -18,7 +18,7 @@ export const KnownSite = ({
           href={site.origin}
           target='_blank'
           rel='noreferrer'
-          className='decoration-green hover:underline'
+          className='truncate decoration-green hover:underline'
         >
           <DisplayOriginURL url={new URL(site.origin)} />
         </a>


### PR DESCRIPTION
Closes #118 

<img width="398" alt="image" src="https://github.com/user-attachments/assets/acd06b27-62a8-4efb-a9be-8a053056945c">
