### PR TITLE
Revert "fix(extension): #107: allow http for localhost"

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chrome-extension",
-  "version": "11.13.0",
+  "version": "11.13.1",
   "private": true,
   "license": "(MIT OR Apache-2.0)",
   "description": "chrome-extension",

--- a/apps/extension/public/manifest.json
+++ b/apps/extension/public/manifest.json
@@ -16,7 +16,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://*/*", "http://localhost:*/*"],
+      "matches": ["https://*/*"],
       "js": [
         "injected-connection-port.js",
         "injected-disconnect-listener.js",
@@ -25,7 +25,7 @@
       "run_at": "document_start"
     },
     {
-      "matches": ["https://*/*", "http://localhost:*/*"],
+      "matches": ["https://*/*"],
       "js": ["injected-penumbra-global.js"],
       "run_at": "document_start",
       "world": "MAIN"

--- a/apps/extension/public/manifest.json
+++ b/apps/extension/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Prax wallet",
-  "version": "11.13.0",
+  "version": "11.13.1",
   "description": "For use in interacting with the Penumbra blockchain",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvnucOJi878TGZYnTNTrvXd9krAcpSDR/EgHcQhvjNZrKfRRsKA9O0DnbyM492c3hiicYPevRPLPoKsLgVghGDYPr8eNO7ee165keD5XLxq0wpWu14gHEPdQSRNZPLeawLp4s/rUwtzMcxhVIUYYaa2xZri4Tqx9wpR7YR1mQTAL8UsdjyitrnzTM20ciKXq1pd82MU74YaZzrcQCOmcjJtjHFdMEAYme+LuZuEugAgef9RiE/8kLQ6T7W9feYfQOky1OPjBkflpRXRgW6cACdl+MeYhKJCOHijglFsPOXX6AvnoJSeAJYRXOMVJi0ejLKEcrLpaeHgh+1WXUvc5G4wIDAQAB",
   "minimum_chrome_version": "119",

--- a/apps/extension/src/senders/validate.ts
+++ b/apps/extension/src/senders/validate.ts
@@ -6,12 +6,12 @@ type ValidSender = chrome.runtime.MessageSender & {
   frameId: 0;
   documentId: string;
   tab: chrome.tabs.Tab & { id: number };
-  origin: string;
-  url: string;
-};
 
-const isHttpLocalhost = (url: URL): boolean =>
-  url.protocol === 'http:' && url.hostname === 'localhost';
+  // the relationship between origin and url is pretty complex.
+  // just rely on the browser's tools.
+  origin: `${ValidProtocol}//${string}`;
+  url: `${ValidProtocol}//${string}/${string}`;
+};
 
 export const assertValidSender = (sender?: chrome.runtime.MessageSender) => {
   if (!sender) {
@@ -34,13 +34,7 @@ export const assertValidSender = (sender?: chrome.runtime.MessageSender) => {
   if (parsedOrigin.origin !== sender.origin) {
     throw new Error('Sender origin is invalid');
   }
-
-  if (
-    !(
-      parsedOrigin.protocol in ValidProtocol ||
-      (globalThis.__DEV__ && isHttpLocalhost(parsedOrigin))
-    )
-  ) {
+  if (!(parsedOrigin.protocol in ValidProtocol)) {
     throw new Error(`Sender protocol is not ${Object.values(ValidProtocol).join(',')}`);
   }
 


### PR DESCRIPTION
Reverts prax-wallet/web#129

<img width="1438" alt="Screenshot 2024-08-08 at 9 07 58 AM" src="https://github.com/user-attachments/assets/e1916d1f-641d-479e-8a5c-4765984c6fd7">

@VanishMax looks like this change is not allowed by the chrome dev dashboard. Reverting for now to unblock release.