### PR TITLE
Install devDeps as well

### DIFF
--- a/.github/workflows/extension-upload.yml
+++ b/.github/workflows/extension-upload.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           node-version: '22'
           cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile
+      - run: pnpm install --frozen-lockfile --prod false # will install devDeps as well
       - run: pnpm turbo build --cache-dir=.turbo
 
       # Outputs beta.zip and prod.zip


### PR DESCRIPTION
Dev deps required for post install. Not being installed after https://github.com/prax-wallet/web/pull/170.

Overriding in the github action. Perhaps there's a more proper way here, but adding this for now to unblock release.