### PR TITLE
 inject request method without handling neutered port

### DIFF
--- a/apps/extension/src/content-scripts/injected-penumbra-global.ts
+++ b/apps/extension/src/content-scripts/injected-penumbra-global.ts
@@ -57,6 +57,7 @@ class PraxInjection {
   private stateEvents = new EventTarget();
 
   private injection: Readonly<PenumbraProvider> = Object.freeze({
+    request: () => this.postConnectRequest().then(() => Promise.resolve()),
     connect: () => Promise.resolve(this.port ?? this.postConnectRequest()),
     disconnect: () => this.postDisconnectRequest(),
     isConnected: () => Boolean(this.port && this.presentState === PenumbraState.Connected),

--- a/apps/extension/src/content-scripts/injected-penumbra-global.ts
+++ b/apps/extension/src/content-scripts/injected-penumbra-global.ts
@@ -57,7 +57,14 @@ class PraxInjection {
   private stateEvents = new EventTarget();
 
   private injection: Readonly<PenumbraProvider> = Object.freeze({
+    /**
+     * Meet the 'request' method of the old page API to mitigate incompatibility
+     * with pd v0.80.0's bundled minifront. This prevents connection failure.
+     * @todo Remove when bundled frontends are updated beyond `a31d54a`
+     * @issue https://github.com/prax-wallet/web/issues/175
+     */
     request: () => this.postConnectRequest().then(() => Promise.resolve()),
+
     connect: () => Promise.resolve(this.port ?? this.postConnectRequest()),
     disconnect: () => this.postDisconnectRequest(),
     isConnected: () => Boolean(this.port && this.presentState === PenumbraState.Connected),

--- a/apps/extension/src/content-scripts/injected-penumbra-global.ts
+++ b/apps/extension/src/content-scripts/injected-penumbra-global.ts
@@ -63,7 +63,9 @@ class PraxInjection {
      * @todo Remove when bundled frontends are updated beyond `a31d54a`
      * @issue https://github.com/prax-wallet/web/issues/175
      */
-    request: () => this.postConnectRequest().then(() => Promise.resolve()),
+    request: async () => {
+      await Promise.resolve(this.port ?? this.postConnectRequest());
+    },
 
     connect: () => Promise.resolve(this.port ?? this.postConnectRequest()),
     disconnect: () => this.postDisconnectRequest(),


### PR DESCRIPTION
prevents issue that reverted #173

there may still be some way to trigger it, but both minifronts seem ok