### PR TITLE
prep v13.0

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chrome-extension",
-  "version": "12.1.0",
+  "version": "13.0.0",
   "private": true,
   "license": "(MIT OR Apache-2.0)",
   "description": "chrome-extension",

--- a/apps/extension/public/manifest.json
+++ b/apps/extension/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Prax wallet",
-  "version": "12.1.0",
+  "version": "13.0.0",
   "description": "For use in interacting with the Penumbra blockchain",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvnucOJi878TGZYnTNTrvXd9krAcpSDR/EgHcQhvjNZrKfRRsKA9O0DnbyM492c3hiicYPevRPLPoKsLgVghGDYPr8eNO7ee165keD5XLxq0wpWu14gHEPdQSRNZPLeawLp4s/rUwtzMcxhVIUYYaa2xZri4Tqx9wpR7YR1mQTAL8UsdjyitrnzTM20ciKXq1pd82MU74YaZzrcQCOmcjJtjHFdMEAYme+LuZuEugAgef9RiE/8kLQ6T7W9feYfQOky1OPjBkflpRXRgW6cACdl+MeYhKJCOHijglFsPOXX6AvnoJSeAJYRXOMVJi0ejLKEcrLpaeHgh+1WXUvc5G4wIDAQAB",
   "minimum_chrome_version": "119",


### PR DESCRIPTION
prax has already consumed the latest versioned npm packages from https://github.com/penumbra-zone/web/pull/1765.